### PR TITLE
update app.listen

### DIFF
--- a/server.js
+++ b/server.js
@@ -50,6 +50,6 @@ app.put('/image', (req, res) => { image.handleImage(req, res, db)});
 
 app.post('/imageurl', (req, res) => { image.handleApiCall(req, res)})
 
-app.listen(3000, ()=> {
-  console.log('app is running on port 3000');
+app.listen(process.env.PORT || 3000, ()=> {
+  console.log('app is running on port ${process.env.PORT}');
 });


### PR DESCRIPTION
app.listen now accepts an environment variable to run server.js, should one be specified. If the process doesn't specify a port, the default is port 300 just as it has been in localhost development